### PR TITLE
Fix the number of params on CSLReferences

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 * twri-docx template includes new chunk options for formatting table and figure 
 captions provided by officedown. (#11)
+* fix issue with citations causing pdf build failures.
 
 # twriTemplates 0.2.1
 ## New features

--- a/inst/rmarkdown/templates/twri-pdf/skeleton/template.tex
+++ b/inst/rmarkdown/templates/twri-pdf/skeleton/template.tex
@@ -182,7 +182,7 @@ $if(csl-refs)$
 % For pandoc 2.11+ using new --citeproc
 \newlength{\csllabelwidth}
 \setlength{\csllabelwidth}{3em}
-\newenvironment{CSLReferences}[3] % #1 hanging-ident, #2 entry spacing
+\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry spacing
  {% don't indent paragraphs
   \setlength{\parindent}{0pt}
   % turn on hanging indent if param 1 is 1


### PR DESCRIPTION
 - This is to fix a [complilation error](https://github.com/jgm/pandoc/issues/7215) with the newer pandoc.